### PR TITLE
Refactoring #1 - User, Config

### DIFF
--- a/Back-End/Spring Security/login/src/main/java/com/pipiolo/login/config/WebSecurityConfig.java
+++ b/Back-End/Spring Security/login/src/main/java/com/pipiolo/login/config/WebSecurityConfig.java
@@ -14,7 +14,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @RequiredArgsConstructor
 @EnableWebSecurity
 @Configuration
-public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
+public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final UserService userService;
     private final PasswordEncoder passwordEncoder;

--- a/Back-End/Spring Security/login/src/main/java/com/pipiolo/login/domain/User.java
+++ b/Back-End/Spring Security/login/src/main/java/com/pipiolo/login/domain/User.java
@@ -29,6 +29,7 @@ public class User implements UserDetails {
     private String password;
 
     @Column(nullable = false)
+    @Enumerated(value = EnumType.STRING)
     private Role role;
 
     @Builder
@@ -42,10 +43,6 @@ public class User implements UserDetails {
         this.email = email;
         this.password = password;
         this.role = role;
-    }
-
-    public boolean isPwMatch(String password) {
-        return password.equals(this.password);
     }
 
     @Override


### PR DESCRIPTION
Role Enum의 값을 디폴트에서 스트링으로 변경

사용하지 않는 isPwMatch() 메소드 삭제
해당 메소드는 로그인시 필요한 기능이었으나, Spring Security가 로그인시 자동 비밀번호 비교함

클래스명 변경
(SpringSecurityConfig -> WebSecurityConfig)